### PR TITLE
Update tox to use seperate coverage files for testenvs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ commands =
 deps =
     --editable=git+https://github.com/Pylons/pyramid.git#egg=pyramid
 
+setenv =
+    COVERAGE_FILE=.coverage.{envname}
+
 [testenv:coverage]
 skip_install = True
 basepython = python3.5
@@ -29,6 +32,8 @@ commands =
     coverage report --fail-under=100
 deps =
     coverage
+setenv =
+    COVERAGE_FILE=.coverage
 
 [testenv:docs]
 basepython = python3.5


### PR DESCRIPTION
This allows coverage to correctly merge coverage reports from each of
the different Python versions, so that we get full coverage even on our
Py3/Py2 lines.

Probably required before #1 fully functions, since I moved some of the no cover statements around.