### PR TITLE
rename the view predicates to last_retry_attempt and retryable_error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+unreleased
+==========
+
+- Rename the view predicates to ``last_retry_attempt`` and
+  ``retryable_error``. See https://github.com/Pylons/pyramid_retry/pull/3
+
+- Rename ``pyramid_retry.is_exc_retryable`` to
+  ``pyramid_retry.is_error_retryable``.
+  See https://github.com/Pylons/pyramid_retry/pull/3
+
 0.2 (2017-03-02)
 ================
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,14 +8,14 @@
 
   .. autofunction:: RetryableExecutionPolicy
 
-  .. autofunction:: is_exc_retryable
+  .. autofunction:: is_error_retryable
 
   .. autofunction:: is_last_attempt
 
   .. autoclass:: LastAttemptPredicate
      :members:
 
-  .. autoclass:: RetryableExceptionPredicate
+  .. autoclass:: RetryableErrorPredicate
      :members:
 
   .. autoexception:: RetryableException

--- a/src/pyramid_retry/__init__.py
+++ b/src/pyramid_retry/__init__.py
@@ -23,7 +23,7 @@ class RetryableException(Exception):
     """ A retryable exception should be raised when an error occurs."""
 
 
-def RetryableExecutionPolicy(attempts=1):
+def RetryableExecutionPolicy(attempts=3):
     """
     Create a :term:`execution policy` that catches any
     :term:`retryable error` and sends it through the pipeline again up to
@@ -69,7 +69,7 @@ def RetryableExecutionPolicy(attempts=1):
                 if exc is not None:
                     # if this is a retryable exception then continue to the
                     # next attempt, discarding the current response
-                    if is_exc_retryable(request, exc):
+                    if is_error_retryable(request, exc):
                         continue
 
                 return response
@@ -80,7 +80,7 @@ def RetryableExecutionPolicy(attempts=1):
                     # if this was the last attempt or the exception is not
                     # retryable then make a last ditch effort to render an
                     # error response before sending the exception up the stack
-                    if not is_exc_retryable(request, exc_info[1]):
+                    if not is_error_retryable(request, exc_info[1]):
                         try:
                             return request.invoke_exception_view(exc_info)
                         except HTTPNotFound:
@@ -97,7 +97,7 @@ def RetryableExecutionPolicy(attempts=1):
     return retry_policy
 
 
-def is_exc_retryable(request, exc):
+def is_error_retryable(request, exc):
     """
     Return ``True`` if the exception is recognized as :term:`retryable error`.
 
@@ -134,9 +134,9 @@ def is_last_attempt(request):
     return attempt + 1 == attempts
 
 
-class RetryableExceptionPredicate(object):
+class RetryableErrorPredicate(object):
     """
-    A :term:`view predicate` registered as ``is_exc_retryable``. Can be
+    A :term:`view predicate` registered as ``retryable_error``. Can be
     used to determine if an exception view should execute based on whether
     the exception is a :term:`retryable error`.
 
@@ -147,13 +147,13 @@ class RetryableExceptionPredicate(object):
         self.val = val
 
     def text(self):
-        return 'exc_is_retryable = %s' % (self.val,)
+        return 'retryable_error = %s' % (self.val,)
 
     phash = text
 
     def __call__(self, context, request):
         exc = getattr(request, 'exception', None)
-        is_retryable = is_exc_retryable(request, exc)
+        is_retryable = is_error_retryable(request, exc)
         return (
             (self.val and is_retryable)
             or (not self.val and not is_retryable)
@@ -162,7 +162,7 @@ class RetryableExceptionPredicate(object):
 
 class LastAttemptPredicate(object):
     """
-    A :term:`view predicate` registered as ``is_last_attempt``. Can be used
+    A :term:`view predicate` registered as ``last_retry_attempt``. Can be used
     to determine if an exception view should execute based on whether it's
     the last retry attempt before aborting the request.
 
@@ -186,11 +186,11 @@ def includeme(config):
     """
     Activate the ``pyramid_retry`` execution policy in your application.
 
-    This will add the :func:`pyramid_retry.RetryableExecutionPolicy` with
+    This will add the :func:`pyramid_retry.RetryableErrorPolicy` with
     ``attempts`` pulled from the ``retry.attempts`` setting.
 
-    Also, the ``is_last_attempt`` and ``is_exc_retryable`` view predicates
-    are also registered.
+    The ``last_retry_attempt`` and ``retryable_error`` view predicates
+    are registered.
 
     This should be included in your Pyramid application via
     ``config.include('pyramid_retry')``.
@@ -204,5 +204,5 @@ def includeme(config):
     policy = RetryableExecutionPolicy(attempts)
     config.set_execution_policy(policy)
 
-    config.add_view_predicate('is_last_attempt', LastAttemptPredicate)
-    config.add_view_predicate('is_exc_retryable', RetryableExceptionPredicate)
+    config.add_view_predicate('last_retry_attempt', LastAttemptPredicate)
+    config.add_view_predicate('retryable_error', RetryableErrorPredicate)

--- a/src/pyramid_retry/__init__.py
+++ b/src/pyramid_retry/__init__.py
@@ -1,3 +1,4 @@
+from pyramid.exceptions import ConfigurationError
 from pyramid.httpexceptions import HTTPNotFound
 import sys
 from zope.interface import (
@@ -144,6 +145,11 @@ class RetryableErrorPredicate(object):
 
     """
     def __init__(self, val, config):
+        if not isinstance(val, bool):
+            raise ConfigurationError(
+                'The "retryable_error" view predicate value must be '
+                'True or False.',
+            )
         self.val = val
 
     def text(self):
@@ -170,6 +176,11 @@ class LastAttemptPredicate(object):
 
     """
     def __init__(self, val, config):
+        if not isinstance(val, bool):
+            raise ConfigurationError(
+                'The "last_retry_attempt" view predicate value must be '
+                'True or False.',
+            )
         self.val = val
 
     def text(self):

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -13,8 +13,8 @@ def test_raising_RetryableException_is_caught(config):
     def bad_view(request):
         calls.append('fail')
         raise RetryableException
-    config.add_view(bad_view, is_last_attempt=False)
-    config.add_view(final_view, is_last_attempt=True, renderer='string')
+    config.add_view(bad_view, last_retry_attempt=False)
+    config.add_view(final_view, last_retry_attempt=True, renderer='string')
     app = config.make_wsgi_app()
     app = webtest.TestApp(app)
     response = app.get('/')
@@ -32,8 +32,8 @@ def test_raising_IRetryableError_is_caught(config):
         ex = Exception()
         zope.interface.directlyProvides(ex, IRetryableError)
         raise ex
-    config.add_view(bad_view, is_last_attempt=False)
-    config.add_view(final_view, is_last_attempt=True, renderer='string')
+    config.add_view(bad_view, last_retry_attempt=False)
+    config.add_view(final_view, last_retry_attempt=True, renderer='string')
     app = config.make_wsgi_app()
     app = webtest.TestApp(app)
     response = app.get('/')
@@ -67,7 +67,7 @@ def test_handled_error_is_retried(config):
     config.add_view(bad_view)
     config.add_exception_view(default_exc_view, renderer='string')
     config.add_exception_view(
-        retryable_exc_view, is_exc_retryable=True, renderer='string')
+        retryable_exc_view, retryable_error=True, renderer='string')
     app = config.make_wsgi_app()
     app = webtest.TestApp(app)
     response = app.get('/')

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -91,3 +91,15 @@ def test_is_last_attempt_True_when_inactive():
     from pyramid_retry import is_last_attempt
     request = pyramid.request.Request.blank('/')
     assert is_last_attempt(request)
+
+def test_retryable_error_predicate_is_bool(config):
+    from pyramid.exceptions import ConfigurationError
+    view = lambda r: 'ok'
+    with pytest.raises(ConfigurationError):
+        config.add_view(view, retryable_error='yes', renderer='string')
+
+def test_last_retry_attempt_predicate_is_bool(config):
+    from pyramid.exceptions import ConfigurationError
+    view = lambda r: 'ok'
+    with pytest.raises(ConfigurationError):
+        config.add_view(view, last_retry_attempt='yes', renderer='string')


### PR DESCRIPTION
Just shaking out the alpha-quality naming of view predicates.