### PR TITLE
add an activate_hook that can override the retry attempts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 unreleased
 ==========
 
+- Support a ``retry.activate_hook`` setting which can return a per-request
+  number of retries. See https://github.com/Pylons/pyramid_retry/pull/4
+
+- Configuration is deferred so that settings may be changed after
+  ``config.include('pyramid_retry')`` is invoked until the configurator
+  is committed. See https://github.com/Pylons/pyramid_retry/pull/4
+
 - Rename the view predicates to ``last_retry_attempt`` and
   ``retryable_error``. See https://github.com/Pylons/pyramid_retry/pull/3
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,6 +120,25 @@ interface:
    def view(request):
        response = requests.get('https://www.google.com')
 
+Per-Request Attempts
+--------------------
+
+It may be desirable to override the attempts per-request. For example, if
+one endpoint on the system cannot afford to make a copy of the request via
+``request.make_body_seekable()`` then the activate hook can be used to
+set ``attempts=`` on that endpoint.
+
+.. code-block:: python
+
+    def activate_hook(request):
+        if request.path == '/upload':
+            return 1  # disable retries on this endpoint
+
+    config.add_settings({'retry.activate_hook': activate_hook})
+
+The ``activate_hook`` should return a number ``>= 1`` or ``None``. If ``None``
+then the policy will fallback to the ``retry.attempts`` setting.
+
 View Predicates
 ---------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,10 @@ import pytest
 
 @pytest.yield_fixture
 def config():
-    config = pyramid.testing.setUp(settings={'retry.attempts': 3})
+    config = pyramid.testing.setUp(
+        settings={'retry.attempts': 3},
+        autocommit=False,
+    )
     config.include('pyramid_retry')
     yield config
     pyramid.testing.tearDown()


### PR DESCRIPTION
This would be desirable if you have a particular endpoint that should not make the body seekable for performance reasons.