### PR TITLE
Add exception and response to BeforeRetry event

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -111,3 +111,5 @@ Contributors
 - Steve Piercy (2017-06-10)
 
 - Bert JW Regeer (2018-10-17)
+
+- Sean Hammond (2019-09-27)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,3 +26,4 @@
   .. autointerface:: IRetryableError
 
   .. autointerface:: IBeforeRetry
+     :members:


### PR DESCRIPTION
`event.exception` is always the exception that was raised during view processing, regardless of whether or not any exception view caught this exception and generated a response.

`event.response` is the error response that view processing returned (for example from an exception view) or `None` if no response was generated (if an uncaught exception was raised).

This makes it possible for `IBeforeRetry` subscribers to access the exception that was raised, even when no response was generated.

Fixes https://github.com/Pylons/pyramid_retry/issues/18