### PR TITLE
clean-up-threadmanager-on-exception

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -113,3 +113,5 @@ Contributors
 - Bert JW Regeer (2018-10-17)
 
 - Sean Hammond (2019-09-27)
+
+- Keenan Graham (2020-03-20)

--- a/src/pyramid_retry/__init__.py
+++ b/src/pyramid_retry/__init__.py
@@ -99,8 +99,9 @@ def RetryableExecutionPolicy(attempts=3, activate_hook=None):
                 request.make_body_seekable()
 
         # Catch make_body_seekable (e.g. 408 RequestTimeout)
-        # and activate_hook exceptions and clean up.
-        except Exception:
+        # and activate_hook exceptions and clean up. Use BaseException
+        # here to catch e.g. GeneratorExit.
+        except BaseException:
             request_ctx.end()
             raise
 

--- a/src/pyramid_retry/__init__.py
+++ b/src/pyramid_retry/__init__.py
@@ -99,8 +99,7 @@ def RetryableExecutionPolicy(attempts=3, activate_hook=None):
                 request.make_body_seekable()
 
         # Catch make_body_seekable (e.g. 408 RequestTimeout)
-        # and activate_hook exceptions and clean up. Use BaseException
-        # here to catch e.g. GeneratorExit.
+        # and activate_hook exceptions and clean up.
         except BaseException:
             request_ctx.end()
             raise

--- a/src/pyramid_retry/__init__.py
+++ b/src/pyramid_retry/__init__.py
@@ -96,7 +96,14 @@ def RetryableExecutionPolicy(attempts=3, activate_hook=None):
         # attempts. make_body_seekable will copy wsgi.input if
         # necessary, otherwise it will rewind the copy to position zero
         if retry_attempts != 1:
-            request.make_body_seekable()
+            try:
+                request.make_body_seekable()
+            # Catch read errors (e.g. 408 - HTTPRequestTimeout)
+            # and clean up. Could be more specific here but probably
+            # want to clean up on any exception.
+            except Exception:
+                request_ctx.end()
+                raise
 
         for number in range(retry_attempts):
             # track the attempt info in the environ


### PR DESCRIPTION
Exceptions in the `retry_policy` after a request has been pushed into Pyramid’s ThreadLocalManger stack (`request_ctx.begin()`) but before the try block has been reached cause the code to exit before popping the request from the stack (`request_ctx.end()`). This can leak state across requests.

https://github.com/Pylons/pyramid_retry/blob/99501c97e1654a5f5874ad877c780664641a2c32/src/pyramid_retry/__init__.py#L83-L99

The fix here is to put both `make_body_seekable` and `activate_hook` into a try block that calls `request_ctx.end()` before raising the exception. 

Fixes https://github.com/Pylons/pyramid_retry/issues/21