### PR TITLE
Add support for Python 3.8 and 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ language: python
 
 matrix:
   include:
+    - python: 3.9
+      env: TOXENV=py39
+      dist: xenial
+      sudo: true
+    - python: 3.8
+      env: TOXENV=py38
+      dist: xenial
+      sudo: true
     - python: 3.7
       env: TOXENV=py37
       dist: xenial

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and 3.7, and for PyPy.
+3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8 and 3.9, and for PyPy.
    Check https://travis-ci.org/Pylons/pyramid_retry/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -115,3 +115,5 @@ Contributors
 - Sean Hammond (2019-09-27)
 
 - Keenan Graham (2020-03-20)
+
+- Jon Betts (2021-04-15)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,11 @@
 environment:
   matrix:
+    # - PYTHON: "C:\\Python39"
+    #   TOXENV: "py39"
+    - PYTHON: "C:\\Python38"
+      TOXENV: "py38"
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37"
     - PYTHON: "C:\\Python36"
       TOXENV: "py36"
     - PYTHON: "C:\\Python35"

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pyramid.testing
 import pytest
 
-@pytest.yield_fixture
+@pytest.fixture
 def config():
     config = pyramid.testing.setUp(
         settings={'retry.attempts': 3},

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py27,py34,py35,py36,py37,pypy,pypy3,
+    py27,py34,py35,py36,py37,py38,py39,pypy,pypy3,
     docs,coverage
 
 [testenv]


### PR DESCRIPTION
This upgrades the tests and various CI files to include Python 3.8 and 3.9.

This also:

 * Adds them to the declared classifiers
 * Updates the contributors agreement to mention them too
 * Fixes a small deprecation warning from the tests
 
I don't have a way of verifying the `appveyor.yml` or Travis changes locally, but the tests pass on those versions of Python I can install locally.