### PR TITLE
lint: add type hints and test for them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,23 @@ no_lines_before = "THIRDPARTY"
 sections = "FUTURE,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
 default_section = "THIRDPARTY"
 known_first_party = "pyramid_retry"
+
+[tool.mypy]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+plugins = ["mypy_zope:plugin"]
+
+[[tool.mypy.overrides]]
+# https://github.com/Pylons/pyramid/issues/2638
+module = "pyramid.*"
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
+        'Typing :: Typed',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ commands =
     isort --check-only --df src/pyramid_retry tests setup.py
     black --check --diff src/pyramid_retry tests setup.py
     flake8 src/pyramid_retry tests setup.py
+    mypy src/pyramid_retry
     check-manifest
     # build sdist/wheel
     python -m build .
@@ -50,6 +51,8 @@ deps =
     flake8
     flake8-bugbear
     isort
+    mypy
+    mypy-zope
     readme_renderer
     twine
 


### PR DESCRIPTION
Introduce `mypy` and apply strict type hints.
Declare typed support via marker file and classifier.